### PR TITLE
Fixed `applyDelta` for arrays with unequal length.

### DIFF
--- a/packages/cloudflare-do-utils/src/apply-delta.js
+++ b/packages/cloudflare-do-utils/src/apply-delta.js
@@ -1,12 +1,18 @@
 /* eslint-disable no-param-reassign */
 function innerApplyDelta(obj, delta) {
-  for (const key of Object.keys(delta)) {
+  const keys = Object.keys(delta);
+  for (let i = keys.length - 1; i >= 0; i--) {
+    const key = keys[i];
     if (Array.isArray(delta[key]) || delta[key] instanceof Set || delta[key] instanceof Map) {
       obj[key] = delta[key]
     } else if (delta[key] instanceof Object) {
       obj[key] = innerApplyDelta(obj[key] ?? {}, delta[key])
     } else if (delta[key] === undefined) {
-      delete obj[key]
+      if (Array.isArray(obj)) {
+        obj.splice(Number(key), 1);
+      } else {
+        delete obj[key];
+      }
     } else {
       obj[key] = delta[key]
     }


### PR DESCRIPTION
I found a minor bug in [applyDelta](https://github.com/DeclineThyself/blueprint/blob/master/packages/cloudflare-do-utils/src/apply-delta.js) and [applyDiff](https://github.com/transformation-dev/blueprint/blob/4330d3045ef7b1838612e026bafaabd2637f55c6/packages/cloudflare-do-utils/src/apply-diff.js).

To reproduce:
```javascript
lhs = ["1", "2", "3"]
rhs = ["1"]
rhsDiff = diff(lhs, rhs)
restoredRHS = applyDelta(structuredClone(lhs), rhsDiff) console.log("rhsDiff", rhsDiff)
console.log("lhs", lhs)
console.log("rhs", rhs)
console.log("restoredRHS", restoredRHS)

//This should output true.
lodash.isEqual(restoredRHS, rhs)
```

When iterating over arrays using a `for of` loop, `delete` will change the length of the array, causing keys to be skipped.
Here's a similar issue and solution: https://stackoverflow.com/a/28122081

Please also consider updating or deprecating your [npm package](https://npm.io/package/@transformation-dev/deep-object-diff-apply).